### PR TITLE
hack: update vendor dockerfile

### DIFF
--- a/hack/dockerfiles/vendor.Dockerfile
+++ b/hack/dockerfiles/vendor.Dockerfile
@@ -1,9 +1,11 @@
 # syntax = docker/dockerfile:1.0-experimental
 FROM golang:1.12-alpine AS vendored
-RUN  apk add --no-cache git
+RUN  apk add --no-cache git rsync
 WORKDIR /src
-RUN --mount=target=/src,rw \
+RUN --mount=target=/context \
+  --mount=target=.,type=tmpfs,readwrite  \
   --mount=target=/go/pkg/mod,type=cache \
+  rsync -a /context/. . && \
   go mod tidy && go mod vendor && \
   mkdir /out && cp -r go.mod go.sum vendor /out
 
@@ -11,7 +13,9 @@ FROM scratch AS update
 COPY --from=vendored /out /out
 
 FROM vendored AS validate
-RUN --mount=target=.,rw \
+RUN --mount=target=/context \
+  --mount=target=.,type=tmpfs,readwrite  \
+  rsync -a /context/. . && \
   git add -A && \
   rm -rf vendor && \
   cp -rf /out/* . && \


### PR DESCRIPTION
Avoid writing on top of build context that forces a new context transfer every time and invalidates cache.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>