### PR TITLE
cmd: allow invoking without plugin

### DIFF
--- a/cmd/buildx/main.go
+++ b/cmd/buildx/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli-plugins/plugin"
 	"github.com/docker/cli/cli/command"
+	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/spf13/cobra"
 	"github.com/tonistiigi/buildx/commands"
 	"github.com/tonistiigi/buildx/version"
@@ -13,8 +17,25 @@ import (
 )
 
 func main() {
+	if os.Getenv("DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND") == "" {
+		if len(os.Args) < 2 || os.Args[1] != manager.MetadataSubcommandName {
+			dockerCli, err := command.NewDockerCli()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			opts := cliflags.NewClientOptions()
+			dockerCli.Initialize(opts)
+			rootCmd := commands.NewRootCmd(os.Args[0], false, dockerCli)
+			if err := rootCmd.Execute(); err != nil {
+				os.Exit(1)
+			}
+			os.Exit(0)
+		}
+	}
+
 	plugin.Run(func(dockerCli command.Cli) *cobra.Command {
-		return commands.NewRootCmd(dockerCli)
+		return commands.NewRootCmd("buildx", true, dockerCli)
 	},
 		manager.Metadata{
 			SchemaVersion: "0.1.0",

--- a/commands/root.go
+++ b/commands/root.go
@@ -6,14 +6,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewRootCmd(dockerCli command.Cli) *cobra.Command {
+func NewRootCmd(name string, isPlugin bool, dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Short: "Build with BuildKit",
-		Use:   "buildx",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return plugin.PersistentPreRunE(cmd, args)
-		},
+		Use:   name,
 	}
+	if isPlugin {
+		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+			return plugin.PersistentPreRunE(cmd, args)
+		}
+	}
+
 	addCommands(cmd, dockerCli)
 	return cmd
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -101,6 +101,7 @@ github.com/docker/cli/cli/compose/types
 github.com/docker/cli/cli-plugins/manager
 github.com/docker/cli/cli-plugins/plugin
 github.com/docker/cli/cli/command
+github.com/docker/cli/cli/flags
 github.com/docker/cli/cli
 github.com/docker/cli/cli/compose/interpolation
 github.com/docker/cli/cli/compose/schema
@@ -115,7 +116,6 @@ github.com/docker/cli/cli/context/docker
 github.com/docker/cli/cli/context/kubernetes
 github.com/docker/cli/cli/context/store
 github.com/docker/cli/cli/debug
-github.com/docker/cli/cli/flags
 github.com/docker/cli/cli/manifest/store
 github.com/docker/cli/cli/registry/client
 github.com/docker/cli/cli/streams


### PR DESCRIPTION
Allow invoking `buildx` binary directly, not only with `docker buildx`

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>