### PR TITLE
commands: driver management command stubs

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+type createOptions struct {
+	name         string
+	driver       string
+	nodeName     string
+	platform     []string
+	actionAppend bool
+	actionLeave  bool
+	// upgrade      bool // perform upgrade of the driver
+}
+
+func runCreate(dockerCli command.Cli, in createOptions) error {
+	fmt.Printf("%+v\n", in)
+	return nil
+}
+
+func createCmd(dockerCli command.Cli) *cobra.Command {
+	var options createOptions
+
+	cmd := &cobra.Command{
+		Use:   "create [OPTIONS] [CONTEXT|ENDPOINT]",
+		Short: "Create a new builder instance",
+		Args:  cli.RequiresMaxArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCreate(dockerCli, options)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVar(&options.name, "name", "", "Builder instance name")
+	flags.StringVar(&options.driver, "driver", "", "Driver to use (eg. docker-container)")
+	flags.StringVar(&options.nodeName, "node", "", "Create/modify node with given name")
+	flags.StringArrayVar(&options.platform, "platform", []string{}, "Fixed platforms for current node")
+
+	flags.BoolVar(&options.actionAppend, "append", false, "Append a node to builder instead of changing it")
+	flags.BoolVar(&options.actionLeave, "leave", false, "Remove a node from builder instead of changing it")
+
+	_ = flags
+
+	return cmd
+}

--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -1,0 +1,39 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+type inspectOptions struct {
+	bootstrap bool
+}
+
+func runInspect(dockerCli command.Cli, in inspectOptions) error {
+	fmt.Printf("%+v\n", in)
+	return nil
+}
+
+func inspectCmd(dockerCli command.Cli) *cobra.Command {
+	var options inspectOptions
+
+	cmd := &cobra.Command{
+		Use:   "inspect [NAME]",
+		Short: "Inspect current builder instance",
+		Args:  cli.RequiresMaxArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInspect(dockerCli, options)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.BoolVar(&options.bootstrap, "bootstrap", false, "Ensure builder has booted before inspecting")
+
+	_ = flags
+
+	return cmd
+}

--- a/commands/ls.go
+++ b/commands/ls.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+type lsOptions struct {
+}
+
+func runLs(dockerCli command.Cli, in lsOptions) error {
+	fmt.Printf("current config file: %+v\n", dockerCli.ConfigFile().Filename)
+	fmt.Printf("current context: %+v\n", dockerCli.CurrentContext())
+
+	list, err := dockerCli.ContextStore().ListContexts()
+	if err != nil {
+		return err
+	}
+	for i, l := range list {
+		fmt.Printf("context%d: %+v\n", i, l)
+	}
+
+	return nil
+}
+
+func lsCmd(dockerCli command.Cli) *cobra.Command {
+	var options lsOptions
+
+	cmd := &cobra.Command{
+		Use:   "ls",
+		Short: "List builder instances",
+		Args:  cli.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLs(dockerCli, options)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	// flags.StringArrayVarP(&options.outputs, "output", "o", []string{}, "Output destination (format: type=local,dest=path)")
+
+	_ = flags
+
+	return cmd
+}

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -1,0 +1,34 @@
+package commands
+
+import (
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+type rmOptions struct {
+}
+
+func runRm(dockerCli command.Cli, in rmOptions) error {
+	return nil
+}
+
+func rmCmd(dockerCli command.Cli) *cobra.Command {
+	var options rmOptions
+
+	cmd := &cobra.Command{
+		Use:   "rm [NAME]",
+		Short: "Remove a builder instance",
+		// Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRm(dockerCli, options)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	// flags.StringArrayVarP(&options.outputs, "output", "o", []string{}, "Output destination (format: type=local,dest=path)")
+
+	_ = flags
+
+	return cmd
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -25,5 +25,11 @@ func addCommands(cmd *cobra.Command, dockerCli command.Cli) {
 	cmd.AddCommand(
 		buildCmd(dockerCli),
 		bakeCmd(dockerCli),
+		createCmd(dockerCli),
+		rmCmd(dockerCli),
+		lsCmd(dockerCli),
+		useCmd(dockerCli),
+		inspectCmd(dockerCli),
+		viewCmd(dockerCli),
 	)
 }

--- a/commands/use.go
+++ b/commands/use.go
@@ -1,0 +1,41 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+type useOptions struct {
+	isGlobal  bool
+	isDefault bool
+}
+
+func runUse(dockerCli command.Cli, in useOptions) error {
+	fmt.Printf("%+v\n", in)
+	return nil
+}
+
+func useCmd(dockerCli command.Cli) *cobra.Command {
+	var options useOptions
+
+	cmd := &cobra.Command{
+		Use:   "use [OPTIONS] NAME",
+		Short: "Set the current builder instance",
+		Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUse(dockerCli, options)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.BoolVar(&options.isGlobal, "global", false, "Builder persists context changes")
+	flags.BoolVar(&options.isDefault, "default", false, "Set builder as default for current context")
+
+	_ = flags
+
+	return cmd
+}

--- a/commands/view.go
+++ b/commands/view.go
@@ -1,0 +1,35 @@
+package commands
+
+import (
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+type viewOptions struct {
+}
+
+func runView(dockerCli command.Cli, in viewOptions) error {
+	return nil
+}
+
+func viewCmd(dockerCli command.Cli) *cobra.Command {
+	var options viewOptions
+
+	cmd := &cobra.Command{
+		Use:   "view REF",
+		Short: "Show metadata for image in registry",
+		Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runView(dockerCli, options)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	// flags.StringArrayVarP(&options.outputs, "output", "o", []string{}, "Output destination (format: type=local,dest=path)")
+
+	_ = flags
+
+	return cmd
+}


### PR DESCRIPTION
Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

```
/work # docker buildx

Usage:	docker buildx COMMAND

Build with BuildKit

Commands:
  bake        Build from a file
  build       Start a build
  create      Create a new builder instance
  inspect     Inspect current builder instance
  ls          List builder instances
  rm          Remove a builder instance
  use         Set the current builder instance
  view        Show metadata for image in registry

Run 'docker buildx COMMAND --help' for more information on a command.
/work # docker buildx create --help

Usage:	docker buildx create [OPTIONS] [CONTEXT|ENDPOINT]

Create a new builder instance

Options:
      --append                 Append a node to builder instead of changing it
      --driver string          Driver to use (eg. docker-container)
      --leave                  Remove a node from builder instead of changing it
      --name string            Builder instance name
      --node string            Create/modify node with given name
      --platform stringArray   Fixed platforms for current node
/work # docker buildx use --help

Usage:	docker buildx use [OPTIONS] NAME

Set the current builder instance

Options:
      --default   Set builder as default for current context
      --global    Builder persists context changes
/work # docker buildx inspect --help

Usage:	docker buildx inspect [NAME]

Inspect current builder instance

Options:
      --bootstrap   Ensure builder as booted before inspecting
/work # docker buildx ls
current config file: /root/.docker/config.json
current context: default
context0: {Name:default Metadata:{Description: StackOrchestrator:swarm} Endpoints:map[docker:{Host:unix:///var/run/docker.sock SkipTLSVerify:false}]}
```