### PR TITLE
bake: fix dockerfile and context defaults

### DIFF
--- a/bake/bake_test.go
+++ b/bake/bake_test.go
@@ -1,0 +1,69 @@
+package bake
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadTargets(t *testing.T) {
+	t.Parallel()
+	tmpdir, err := ioutil.TempDir("", "bake")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	fp := filepath.Join(tmpdir, "config.hcl")
+	err = ioutil.WriteFile(fp, []byte(`
+target "dep" {
+}
+
+target "webapp" {
+	dockerfile = "Dockerfile.webapp"
+	inherits = ["dep"]
+}`), 0600)
+	require.NoError(t, err)
+
+	ctx := context.TODO()
+
+	m, err := ReadTargets(ctx, []string{fp}, []string{"webapp"}, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "Dockerfile.webapp", *m["webapp"].Dockerfile)
+	require.Equal(t, ".", *m["webapp"].Context)
+}
+
+func TestReadTargetsCompose(t *testing.T) {
+	t.Parallel()
+	tmpdir, err := ioutil.TempDir("", "bake")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	fp := filepath.Join(tmpdir, "docker-compose.yml")
+	err = ioutil.WriteFile(fp, []byte(`
+version: "3"
+
+services:
+  db:
+    build: .
+    command: ./entrypoint.sh
+    image: docker.io/tonistiigi/db
+  webapp:
+    build:
+      dockerfile: Dockerfile.webapp
+      args:
+        buildno: 1
+`), 0600)
+	require.NoError(t, err)
+
+	ctx := context.TODO()
+
+	m, err := ReadTargets(ctx, []string{fp}, []string{"default"}, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "Dockerfile.webapp", *m["webapp"].Dockerfile)
+	require.Equal(t, ".", *m["webapp"].Context)
+}

--- a/bake/compose.go
+++ b/bake/compose.go
@@ -34,9 +34,19 @@ func ParseCompose(dt []byte) (*Config, error) {
 
 		for _, s := range cfg.Services {
 			g.Targets = append(g.Targets, s.Name)
+			var contextPathP *string
+			if s.Build.Context != "" {
+				contextPath := s.Build.Context
+				contextPathP = &contextPath
+			}
+			var dockerfilePathP *string
+			if s.Build.Dockerfile != "" {
+				dockerfilePath := s.Build.Dockerfile
+				dockerfilePathP = &dockerfilePath
+			}
 			t := Target{
-				Context:    s.Build.Context,
-				Dockerfile: s.Build.Dockerfile,
+				Context:    contextPathP,
+				Dockerfile: dockerfilePathP,
 				Labels:     s.Build.Labels,
 				Args:       toMap(s.Build.Args),
 				CacheFrom:  s.Build.CacheFrom,

--- a/bake/compose_test.go
+++ b/bake/compose_test.go
@@ -32,10 +32,10 @@ services:
 	require.Equal(t, []string{"db", "webapp"}, c.Group["default"].Targets)
 
 	require.Equal(t, 2, len(c.Target))
-	require.Equal(t, "./db", c.Target["db"].Context)
+	require.Equal(t, "./db", *c.Target["db"].Context)
 
-	require.Equal(t, "./dir", c.Target["webapp"].Context)
-	require.Equal(t, "Dockerfile-alternate", c.Target["webapp"].Dockerfile)
+	require.Equal(t, "./dir", *c.Target["webapp"].Context)
+	require.Equal(t, "Dockerfile-alternate", *c.Target["webapp"].Dockerfile)
 	require.Equal(t, 1, len(c.Target["webapp"].Args))
 	require.Equal(t, "123", c.Target["webapp"].Args["buildno"])
 }

--- a/bake/hcl_test.go
+++ b/bake/hcl_test.go
@@ -47,7 +47,7 @@ func TestParseHCL(t *testing.T) {
 	require.Equal(t, []string{"db", "webapp"}, c.Group["default"].Targets)
 
 	require.Equal(t, 4, len(c.Target))
-	require.Equal(t, "./db", c.Target["db"].Context)
+	require.Equal(t, "./db", *c.Target["db"].Context)
 
 	require.Equal(t, 1, len(c.Target["webapp"].Args))
 	require.Equal(t, "123", c.Target["webapp"].Args["buildno"])

--- a/build/build.go
+++ b/build/build.go
@@ -420,7 +420,7 @@ func LoadInputs(inp Inputs, target *client.SolveOpt) (func(), error) {
 }
 
 func notSupported(d driver.Driver, f driver.Feature) error {
-	return errors.Errorf("%s feature is currently not supported for %s driver. Please switch to a different driver (eg. \"docker buildx create\")", f, d.Factory().Name())
+	return errors.Errorf("%s feature is currently not supported for %s driver. Please switch to a different driver (eg. \"docker buildx create --use\")", f, d.Factory().Name())
 }
 
 func newDockerLoader(ctx context.Context, d DockerAPI, name string, mw *progress.MultiWriter) (io.WriteCloser, func(), error) {


### PR DESCRIPTION
Fixes the default values for context/dockerfile. Previously the default value could take precedence over the manual value when targets were combined.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>