### PR TITLE
Add makefile targets to build easily with just go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,28 @@
+PKG=github.com/tonistiigi/buildx
+VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
+LDFLAGS=-X ${PKG}/version.Version=${VERSION} \
+	-X ${PKG}/version.Revision=${REVISION} \
+	-X ${PKG}/version.Package=${PKG}
+
+GOFILES=$(shell find . -type f -name '*.go')
+
+.PHONY: build
+build: plugin
+
+bin/buildx bin/docker-buildx: $(GOFILES)
+	go build -ldflags "$(LDFLAGS)" -o $@ ./cmd/buildx
+
+.PHONY: clean
+clean:
+	$(RM) -r bin/
+
+.PHONY: standalone
+standalone: bin/buildx
+
+.PHONY: plugin
+plugin: bin/docker-buildx
+
 shell:
 	./hack/shell
 
@@ -19,7 +44,7 @@ test:
 
 validate-vendor:
 	./hack/validate-vendor
-	
+
 validate-all: lint test validate-vendor
 
 vendor:


### PR DESCRIPTION
Makes it easier to build inside of containers, including the ability to cross compile easily with usage similar to:

    GOOS=darwin make plugin

Shouldn't change current functionality but it'll make it easier when I'm implementing building this in the Docker CLI pipeline.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>